### PR TITLE
Item5. 의존성 주입 iOS 활용 예시 수정 및 문체 통일

### DIFF
--- a/2장_객체_생성과_파괴/item5.md
+++ b/2장_객체_생성과_파괴/item5.md
@@ -234,3 +234,11 @@ class PhotoGalleryController {
 
 ### 핵심 정리
 클래스가 내부적으로 하나 이상의 자원에 의존하고, 그 자원이 클래스 동작에 영향을 준다면 싱글턴과 정적 유틸리티 클래스는 사용하지 않는 것이 좋습니다. 이 자원들을 클래스가 직접 만들게 해서도 안됩니다. 대신 필요한 자원을(혹은 그 자원을 만들어주는 팩터리를) 생성자에 (혹은 정적 팩터리나 빌더에) 넘겨주는 것이 좋습니다. 의존 객체 주입이라 하는 이 기법은 클래스의 유연성, 재사용성, 테스트 용이성을 개선해줍니다.
+
+### 참고
+
+1. [[DI\] 의존성 주입(Dependency Injection) 을 해주는 세가지 방법](https://eunjin3786.tistory.com/115)
+2. [[DI] Dependency Injection 이란?](https://medium.com/@jang.wangsu/di-dependency-injection-%EC%9D%B4%EB%9E%80-1b12fdefec4f)
+3. [DI(Dependency Injection)에 대해 알아보자 ](https://velog.io/@jojo_devstory/DIDependency-Injection%EC%97%90-%EB%8C%80%ED%95%B4-%EC%95%8C%EC%95%84%EB%B3%B4%EC%9E%90)
+4. [Dependency Injection in Swift](https://cocoacasts.com/dependency-injection-in-swift)
+

--- a/2장_객체_생성과_파괴/item5.md
+++ b/2장_객체_생성과_파괴/item5.md
@@ -1,15 +1,15 @@
 # Item 5. 자원을 직접 명시하지 말고 의존 객체 주입을 사용하라
 
-클래스가 내부적으로 하나 이상의 자원에 의존하고 그 자원이 클래스 동작에 영향을 줄 때의 경우 자원을 직접 명시하지 말고 의존 객체 주입을 사용하라. 
+클래스가 내부적으로 하나 이상의 자원에 의존하고 그 자원이 클래스 동작에 영향을 줄 때의 경우 자원을 직접 명시하지 말고 의존 객체 주입을 사용하는 것이 좋습니다. 
 
 ### 정적 유틸리티와 싱글턴을 잘못 사용한 예  
 
-사용하는 자원에 따라 동작이 달라지는 클래스에서 정적 유틸리티 클래스나 싱글턴 방식은 적합하지 않다.
+사용하는 자원에 따라 동작이 달라지는 클래스에서 정적 유틸리티 클래스나 싱글턴 방식은 적합하지 않습니다.
 
 1. 정적 유틸리티를 잘못 사용한 예
 ```swift
 class SpellChecker {
-  private static let dictionary = Lexicon()
+  private static var dictionary = Lexicon()
   private init() { ... }
   
   static func isValid(word: String) -> Bool { ... } 
@@ -19,7 +19,7 @@ class SpellChecker {
 2. 싱글턴을 잘못 사용한 예
 ```swift
 class SpellChecker {
-  private let dictionary = Lexicon()
+  private var dictionary = Lexicon()
   private init( ... ) {}
   
   static let sharedInstance = SpellChecker()
@@ -40,17 +40,17 @@ class SpellChecker {
 }
 ```
 
-  * 코드 1과 코드 2는 사전을 단 하나만 사용한다고 가정하고 구현하였다. 유연하지 않고 테스트하기 어렵다.
-  * 코드 3은 멀티스레드 환경에서 사용할 수 없다. 
+  * 코드 1과 코드 2는 사전을 단 하나만 사용한다고 가정하고 구현하였습니다. 유연하지 않고 테스트하기 어렵습니다.
+  * 코드 3은 멀티스레드 환경에서 사용할 수 없습니다. 
 
-  **따라서 클래스가 여러 인스턴스를 지원해야하며 클라이언트가 원하는 자원을 사용해야하는 경우에는 정적 유틸리티 클래스나 싱글턴 방식을 사용하기 보다 인스턴스를 생성할 때 생성자에 필요한 자원을 넘겨주자.(의존 객체 주입의 한 형태로 생성자 주입에 해당)**
+  **따라서 클래스가 여러 인스턴스를 지원해야하며 클라이언트가 원하는 자원을 사용해야하는 경우에는 정적 유틸리티 클래스나 싱글턴 방식을 사용하기 보다 인스턴스를 생성할 때 생성자에 필요한 자원을 넘겨주는 것이 좋습니다.(의존 객체 주입의 한 형태로 생성자 주입에 해당)**
 
 ### 생성자 주입을 사용한 예
 
 1. 생성자 주입을 사용한 예 
 ```swift
 class SpellChecker {
-  private let dictionary = Lexicon()
+  private var dictionary = Lexicon()
   private init(newDictionary: Lexicon) {
     self.dictionary = newDictionary
   }
@@ -59,32 +59,31 @@ class SpellChecker {
   func suggestion(typo: String) -> [String] { ... }
 }
 ```
-* 코드 4는 테스트 용이성을 높여준다.
-* 생성자에 팩터리 메서드 패턴(Factory Method pattern)을 이용하여 자원 팩터리(호출할 때마다 특정 타입의 인스턴스를 반복해서 만들어주는 객체)를 넘겨주는 방식으로 변형해 활용할 수 있다.
+* 코드 4는 테스트 용이성을 높여줍니다.
+* 생성자에 팩터리 메서드 패턴(Factory Method pattern)을 이용하여 자원 팩터리(호출할 때마다 특정 타입의 인스턴스를 반복해서 만들어주는 객체)를 넘겨주는 방식으로 변형해 활용할 수 있습니다.
 
 ### 의존성 주입(Dependency Injection)
 
-  * 의존성 주입(Dependency Injection)이란?
-
-    - 의존성: 함수에 필요한 클래스 또는 참조 변수나 객체에 의존하는 것.
+  * **의존성 주입(Dependency Injection)이란?**
+- 의존성: 함수에 필요한 클래스 또는 참조 변수나 객체에 의존하는 것.
     - 주입: 내부에서 필요한 객체를 생성하여 참조/사용하지 않고 외부에서 객체를 생성해 넣어주는 것.
     - 의존성 주입: 코드에서 두 모듈 간의 연결. 객체지향 언어에서는 두 클래스 간의 관계라고도 한다. 
+    
+  * **의존성 주입의 장점**
+    1. 객체 간의 결합도(Coupling)을 낮춰 의존성을 줄여 유지보수가 용이해집니다.
+       - 객체 간 의존성(종속성)이 감소해 변경에 민감하지 않습니다.  
+    2. 재사용성이 증가합니다. 
+    3. 리팩토링이 수월합니다.
+    4. Protocol을 사용하는 경우, Protocol에 구현체를 쉽게 교체하면서 상황에 따라 적절한 행동을 정의할 수 있습니다.
+    5. 테스트가 용이합니다. 
+       - 주입할 의존 객체를 Mock 객체로 구현한 후 주입할 수 있습니다.
+    6. 보일러 플레이트 코드(Boilerplate code , 꼭 필요하면서 간단한 기능에 비해 많은 코드를 필요로 하는 코드를 의미 한다. 예를 들면 setter, getter을 의미한다.) 감소시킬 수 있습니다.
+    7. 같은 자원을 사용하려는 여러 클라이언트가 의존 객체들을 안전하게 공유할 수 있습니다. 
+    8. 생성자, 정적 팩터리, 빌더 모두에 똑같이 응용할 수 있습니다.
 
-  * 의존성 주입의 장점
-    1. 객체 간의 결합도(Coupling)을 낮춰 의존성을 줄여 유지보수가 용이해진다.
-       - 객체 간 의존성(종속성)이 감소해 변경에 민감하지 않다.  
-    2. 재사용성이 증가한다. 
-    3. 리팩토링이 수월하다.
-    4. Protocol을 사용하는 경우, Protocol에 구현체를 쉽게 교체하면서 상황에 따라 적절한 행동을 정의할 수 있다.
-    5. 테스트가 용이하다. 
-       - 주입할 의존 객체를 Mock 객체로 구현한 후 주입할 수 있다.
-    6. 보일러 플레이트 코드(Boilerplate code , 꼭 필요하면서 간단한 기능에 비해 많은 코드를 필요로 하는 코드를 의미 한다. 예를 들면 setter, getter을 의미한다.) 감소시킬 수 있다.
-    7. 같은 자원을 사용하려는 여러 클라이언트가 의존 객체들을 안전하게 공유할 수 있다. 
-    8. 생성자, 정적 팩터리, 빌더 모두에 똑같이 응용할 수 있다.
-
-  * DI의 단점은?
-    1. 의존성 주입을 위한 선행 작업 필요하다.
-    2. 코드를 추척하고 읽기 어려울 수 있다.
+  * **DI의 단점은?**
+    1. 의존성 주입을 위한 선행 작업 필요합니다.
+    2. 코드를 추척하고 읽기 어려울 수 있습니다.
 
 ### 의존성 주입 방법
 
@@ -161,47 +160,33 @@ class SpellChecker {
 ### iOS 활용 예시
 
 1. Property Injection 
-  * Segue, Storyboard를 이용한 ViewController 간 데이터 전달
-  
 ```swift
+// Property Injection 
 import UIKit
 
 class ViewController: UIViewController {
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()        
-    }
-
-    // 의존성 주입 예1
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "segueto" {
-            let destinationVC = segue.destination as! MainViewViewController
-            destinationVC.passedData = "Comes from the inital view controller"
-            destinationVC.delegate = self
-        }
-    }
-
-    // 의존성 주입 예2
-    @IBAction func instantiateButton(_ sender: UIButton) {       
-        let destinationVC = self.storyboard!.instantiateViewController(withIdentifier: "instantiate") as! MainViewViewController
-        destinationVC.passedData = "Comes from the inital view controller"
-        destinationVC.delegate = self
-        self.navigationController!.pushViewController(destinationVC, animated: true)
-    }    
-
-    // 나머지 구현부 생략
+    lazy var requestManager: RequestManager? = RequestManager()
 }
 
-class MainViewViewController: UIViewController {
-    
-    var passedData : String?
-    var delegate : ViewController?
+class newViewController {
+  let viewController = ViewController()
+  viewController.requestManager = RequestManager()
+ }
 
-    // 나머지 구현부 생략
+// Using Protocol
+protocol Serializer {
+    func serialize(data: AnyObject) -> NSData?
+}
+
+class RequestSerializer: Serializer {
+    func serialize(data: AnyObject) -> NSData? {
+        ...
     }
 }
 
-
+class DataManager {
+    var serializer: Serializer? = RequestSerializer()
+}
 ```
 2. Initializer injection
   * 네트워크에 이미지 요청
@@ -246,45 +231,6 @@ class PhotoGalleryController {
   }
 }
 ```
-  * Nib 등록과 ViewController 초기화(Initializer)
-```swift
-import UIKit
-
-class ViewController: UIViewController {
-
-    @IBAction func injectionButton(_ sender: UIButton) {
-        let destinationVC = SomeViewController(display: "test")
-        self.navigationController!.pushViewController(destinationVC, animated: false)
-    }
-
-    // 나머지 구현부 생략
-}  
-
-class SomeViewController: UIViewController {
-
-    var passedData : String
-    
-    @IBOutlet weak var instatiateLabel: UILabel!
-    
-    init(display: String) {
-        self.passedData = display
-        super.init(nibName: "InitializationView", bundle: nil) 
-        // Xib 파일 이름: InitializationView
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        instatiateLabel.text = passedData
-    }
-
-}
-
-```
-
 
 ### 핵심 정리
-클래스가 내부적으로 하나 이상의 자원에 의존하고, 그 자원이 클래스 동작에 영향을 준다면 싱글턴과 정적 유틸리티 클래스는 사용하지 않는 것이 좋다. 이 자원들을 클래스가 직접 만들게 해서도 안된다. 대신 필요한 자원을(혹은 그 자원을 만들어주는 팩터리를) 생성자에 (혹은 정적 팩터리나 빌더에) 넘겨주자. 의존 객체 주입이라 하는 이 기법은 클래스의 유연성, 재사용성, 테스트 용이성을 개선해준다.
+클래스가 내부적으로 하나 이상의 자원에 의존하고, 그 자원이 클래스 동작에 영향을 준다면 싱글턴과 정적 유틸리티 클래스는 사용하지 않는 것이 좋습니다. 이 자원들을 클래스가 직접 만들게 해서도 안됩니다. 대신 필요한 자원을(혹은 그 자원을 만들어주는 팩터리를) 생성자에 (혹은 정적 팩터리나 빌더에) 넘겨주는 것이 좋습니다. 의존 객체 주입이라 하는 이 기법은 클래스의 유연성, 재사용성, 테스트 용이성을 개선해줍니다.

--- a/2장_객체_생성과_파괴/item5.md
+++ b/2장_객체_생성과_파괴/item5.md
@@ -165,7 +165,7 @@ class SpellChecker {
 import UIKit
 
 class ViewController: UIViewController {
-    lazy var requestManager: RequestManager? = RequestManager()
+    var requestManager: RequestManager?
 }
 
 class newViewController {


### PR DESCRIPTION
### 수정한 부분

#4 피드백을 참고하여 Item5를 수정하였습니다.
- 예제 코드: 컴파일 에러가 나는 부분을 해결했습니다.
- iOS 활용 예시: 부적절한 예시는 삭제하고 스터디때 설명한 예시(Property Injection)와 네트워크에 이미지 요청하는 예시(Initializer injection)를 남겨두었습니다.
- 문체를 '-니다'로 통일했습니다.
- 참고한 자료의 링크를 추가했습니다.
